### PR TITLE
Zoom centered around visible part of image

### DIFF
--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -281,6 +281,9 @@
 
 		// Whether or not to transition the scale
 		transition: true,
+		
+		// Whether to zoom from center of "full" image or center of "visible" image
+		zoomCenter: 'full',
 
 		// Default cursor style for the element
 		cursor: 'move',
@@ -736,6 +739,10 @@
 				clientV = offsetM.x(surfaceM.x(surfaceV));
 				matrix[4] = +matrix[4] + (clientX - clientV.e(0));
 				matrix[5] = +matrix[5] + (clientY - clientV.e(1));
+			} else if (options.zoomCentered === 'visible') {
+				// Keep image centered on same coordinates
+				matrix[4] = +matrix[4] * scale / matrix[0];
+				matrix[5] = +matrix[5] * scale / matrix[0];
 			}
 
 			// Set the scale

--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -739,8 +739,8 @@
 				clientV = offsetM.x(surfaceM.x(surfaceV));
 				matrix[4] = +matrix[4] + (clientX - clientV.e(0));
 				matrix[5] = +matrix[5] + (clientY - clientV.e(1));
-			} else if (options.zoomCentered === 'visible') {
-				// Keep image centered on same coordinates
+			} else if (options.zoomCenter === 'visible') {
+				// Keep image centered on middle of visible part of image
 				matrix[4] = +matrix[4] * scale / matrix[0];
 				matrix[5] = +matrix[5] * scale / matrix[0];
 			}


### PR DESCRIPTION
### PR Checklist
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [ ] I have run `grunt` against my changes and both linting and tests pass.
- [ ] I have added tests to prove my fix is affective or my feature works. This can be done in the form of unit tests in `test/bdd/test.js` or a new demo on `demo/index.html`.
- [ ] I have added or edited necessary documentation in the README.md (if appropriate).

### Description
<!--Please describe your pull request. Thank you!-->
I noticed when zoomed in quite far, the zoom range slider behaviour feels unnatural.  The default settings keep zooming around the full image. The part of the image previously shown while zoomed, shown suddenly jumps out of frame when increasing zoom more.

I made a quick fix that should allow the center of zoom to remain on the zoomed in part of the image - by simply scaling the pan x and y of the matrix the same as the zoom.

Now if I have a large image, and go to one corner of it, zooming it feels natural.

Please let me know what you think,
Marko
<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/timmywil/jquery.panzoom/issues).-->

