### PR TITLE
Get transform if it exists

### DIFF
--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -245,7 +245,7 @@
 
 		// Build the appropriately-prefixed transform style property name
 		// De-camelcase
-		this._transform = $.cssProps.transform.replace(rupper, '-$1').toLowerCase();
+		this._transform = $.cssProps.transform ? $.cssProps.transform.replace(rupper, '-$1').toLowerCase() : null;
 
 		// Build the transition value
 		this._buildTransition();


### PR DESCRIPTION
Prevent decoding transform from *$.cssProps* when transform does not exist.

### PR Checklist
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [x] I have run `grunt` against my changes and both linting and tests pass.
- [ ] I have added tests to prove my fix is affective or my feature works. This can be done in the form of unit tests in `test/bdd/test.js` or a new demo on `demo/index.html`.
- [ ] I have added or edited necessary documentation in the README.md (if appropriate).

Testing is broken on Linux:

```
Running "mocha:all" (mocha) task
Testing: test/index.html
Warning: PhantomJS timed out, possibly due to a missing Mocha run() call. Use --force to continue.
Aborted due to warnings.
```

### Description

On jquery 3.4.0 this emerges. Somehow this is accessed `$.cssProps.transform` but it is not present so an exception occurs.

(https://github.com/timmywil/jquery.panzoom/issues).-->
**Fixes**: #

