### PR TITLE
fix(events): remove pointer on event up

### DIFF
--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -387,7 +387,7 @@ function Panzoom(elem: HTMLElement | SVGElement, options?: PanzoomOptions): Panz
 
   function handleUp(event: PointerEvent) {
     if (!isPanning) {
-      return
+      return removePointer(pointers, event)
     }
     // Only call panzoomend once
     if (pointers.length === 1) {


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [x] I have run `yarn test` against my changes and tests pass.
- [ ] I have added tests to prove my fix is affective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary documentation in the README.md, or no docs changes are needed.

### Description

Remove pointer on event up so `getDistance()` will not check on dead pointers.

Fix: https://github.com/timmywil/panzoom/issues/402
