### PR TITLE
feat(handlestartevent): add option to handle the start event

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Alternatively, add a reference to the element to the `exclude` option, or call `
 
 ▸ **Panzoom**(`elem`: HTMLElement | SVGElement, `options?`: Omit‹[PanzoomOptions](#PanzoomOptions), "force"›): _[PanzoomObject](#PanzoomObject)_
 
-_Defined in [panzoom.ts:41](https://github.com/timmywil/panzoom/blob/e8f5210/src/panzoom.ts#L41)_
+_Defined in [panzoom.ts:45](https://github.com/timmywil/panzoom/blob/5a075a0/src/panzoom.ts#L45)_
 
 **Parameters:**
 
@@ -138,7 +138,7 @@ Includes `MiscOptions`, `PanOptions`, and `ZoomOptions`
 
 • **animate**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:13](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L13)_
+_Defined in [types.ts:13](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L13)_
 
 Whether to animate transitions
 
@@ -148,7 +148,7 @@ Whether to animate transitions
 
 • **duration**? : _number_ (Default: **200**)
 
-_Defined in [types.ts:15](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L15)_
+_Defined in [types.ts:15](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L15)_
 
 Duration of the transition (ms)
 
@@ -158,7 +158,7 @@ Duration of the transition (ms)
 
 • **easing**? : _string_ (Default: **"ease-in-out"**)
 
-_Defined in [types.ts:17](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L17)_
+_Defined in [types.ts:17](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L17)_
 
 CSS Easing used for transitions
 
@@ -168,7 +168,7 @@ CSS Easing used for transitions
 
 • **exclude**? : _Element[]_
 
-_Defined in [types.ts:23](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L23)_
+_Defined in [types.ts:23](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L23)_
 
 Add elements to this array that should be excluded
 from Panzoom handling.
@@ -180,7 +180,7 @@ e.g. links and buttons that should not propagate the click event.
 
 • **excludeClass**? : _string_ (Default: **"panzoom-exclude"**)
 
-_Defined in [types.ts:29](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L29)_
+_Defined in [types.ts:29](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L29)_
 
 Add this class to any element within the Panzoom element
 that you want to exclude from Panzoom handling.
@@ -192,7 +192,7 @@ e.g. links and buttons that should not propagate the click event.
 
 • **force**? : _boolean_
 
-_Defined in [types.ts:45](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L45)_
+_Defined in [types.ts:45](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L45)_
 
 `force` should be used sparingly to temporarily
 override and ignore options such as disablePan,
@@ -210,11 +210,51 @@ panzoom.zoom(1, { force: true })
 
 ---
 
+### handleStartEvent
+
+• **handleStartEvent**? : _function_
+
+_Defined in [types.ts:69](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L69)_
+
+On the first pointer event, when panning starts,
+the default Panzoom behavior is to call
+`event.preventDefault()` and `event.stopPropagation()`
+on that event. The former is almost certainly a necesity,
+the latter enables Panzoom elements within Panzoom elements.
+
+But there are some cases where the default is
+not the desired behavior. Set this option to override that behavior.
+
+```js
+// Only call preventDefault()
+Panzoom(elem, {
+  handleStartEvent: (event) => {
+    event.preventDefault()
+  }
+})
+// Do nothing (this probably breaks things on mobile tho)
+Panzoom(elem, {
+  handleStartEvent: () => {}
+})
+```
+
+#### Type declaration:
+
+▸ (`event`: Event): _void_
+
+**Parameters:**
+
+| Name    | Type  |
+| ------- | ----- |
+| `event` | Event |
+
+---
+
 ### origin
 
 • **origin**? : _string_
 
-_Defined in [types.ts:59](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L59)_
+_Defined in [types.ts:83](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L83)_
 
 **Change this at your own risk.**
 The `transform-origin` is the origin from which transforms are applied.
@@ -234,7 +274,7 @@ And again, changing this for SVG in IE doesn't work at all.
 
 • **setTransform**? : _setTransform_
 
-_Defined in [types.ts:77](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L77)_
+_Defined in [types.ts:101](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L101)_
 
 Override the transform setter.
 This is exposed mostly so the user could
@@ -258,7 +298,7 @@ const panzoom = Panzoom(elem, {
 
 • **silent**? : _boolean_
 
-_Defined in [types.ts:79](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L79)_
+_Defined in [types.ts:103](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L103)_
 
 Silence all events
 
@@ -268,7 +308,7 @@ Silence all events
 
 • **startScale**? : _number_ (Default: **1**)
 
-_Defined in [types.ts:85](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L85)_
+_Defined in [types.ts:109](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L109)_
 
 Scale used to set the beginning transform
 
@@ -278,7 +318,7 @@ Scale used to set the beginning transform
 
 • **startX**? : _number_ (Default: **0**)
 
-_Defined in [types.ts:81](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L81)_
+_Defined in [types.ts:105](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L105)_
 
 X Value used to set the beginning transform
 
@@ -288,7 +328,7 @@ X Value used to set the beginning transform
 
 • **startY**? : _number_ (Default: **0**)
 
-_Defined in [types.ts:83](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L83)_
+_Defined in [types.ts:107](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L107)_
 
 Y Value used to set the beginning transform
 
@@ -302,7 +342,7 @@ Includes `MiscOptions`
 
 • **contain**? : _"inside" | "outside"_
 
-_Defined in [types.ts:102](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L102)_
+_Defined in [types.ts:126](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L126)_
 
 Contain the panzoom element either
 inside or outside the parent.
@@ -320,7 +360,7 @@ empty space around the element will be shown.
 
 • **cursor**? : _string_ (Default: **"move"**)
 
-_Defined in [types.ts:104](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L104)_
+_Defined in [types.ts:128](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L128)_
 
 The cursor style to set on the panzoom element
 
@@ -330,7 +370,7 @@ The cursor style to set on the panzoom element
 
 • **disablePan**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:106](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L106)_
+_Defined in [types.ts:130](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L130)_
 
 Disable panning functionality. Note: disablePan also disables focal point zooming
 
@@ -340,7 +380,7 @@ Disable panning functionality. Note: disablePan also disables focal point zoomin
 
 • **disableXAxis**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:108](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L108)_
+_Defined in [types.ts:132](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L132)_
 
 Pan only on the Y axis
 
@@ -350,7 +390,7 @@ Pan only on the Y axis
 
 • **disableYAxis**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:110](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L110)_
+_Defined in [types.ts:134](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L134)_
 
 Pan only on the X axis
 
@@ -360,7 +400,7 @@ Pan only on the X axis
 
 • **panOnlyWhenZoomed**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:114](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L114)_
+_Defined in [types.ts:138](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L138)_
 
 Disable panning while the scale is equal to the starting value
 
@@ -370,7 +410,7 @@ Disable panning while the scale is equal to the starting value
 
 • **relative**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:112](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L112)_
+_Defined in [types.ts:136](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L136)_
 
 When passing x and y values to .pan(), treat the values as relative to their current values
 
@@ -384,7 +424,7 @@ Includes `MiscOptions`
 
 • **disableZoom**? : _boolean_ (Default: **false**)
 
-_Defined in [types.ts:119](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L119)_
+_Defined in [types.ts:143](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L143)_
 
 Disable zooming functionality
 
@@ -394,7 +434,7 @@ Disable zooming functionality
 
 • **focal**? : _object_
 
-_Defined in [types.ts:126](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L126)_
+_Defined in [types.ts:150](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L150)_
 
 Zoom to the given point on the panzoom element.
 This point is expected to be relative to
@@ -413,7 +453,7 @@ to the parent dimensions.
 
 • **maxScale**? : _number_ (Default: **4**)
 
-_Defined in [types.ts:130](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L130)_
+_Defined in [types.ts:154](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L154)_
 
 The maximum scale when zooming
 
@@ -423,7 +463,7 @@ The maximum scale when zooming
 
 • **minScale**? : _number_ (Default: **0.125**)
 
-_Defined in [types.ts:128](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L128)_
+_Defined in [types.ts:152](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L152)_
 
 The minimum scale when zooming
 
@@ -433,7 +473,7 @@ The minimum scale when zooming
 
 • **step**? : _number_ (Default: **0.3**)
 
-_Defined in [types.ts:132](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L132)_
+_Defined in [types.ts:156](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L156)_
 
 The step affects zoom calculation when zooming with a mouse wheel, when pinch zooming, or when using zoomIn/zoomOut
 
@@ -447,7 +487,7 @@ These methods are available after initializing Panzoom
 
 • **destroy**: _function_
 
-_Defined in [types.ts:147](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L147)_
+_Defined in [types.ts:171](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L171)_
 
 Remove all event listeners bind to the the Panzoom element
 
@@ -461,7 +501,7 @@ Remove all event listeners bind to the the Panzoom element
 
 • **getOptions**: _function_
 
-_Defined in [types.ts:153](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L153)_
+_Defined in [types.ts:177](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L177)_
 
 Returns a _copy_ of the current options object
 
@@ -475,7 +515,7 @@ Returns a _copy_ of the current options object
 
 • **getPan**: _function_
 
-_Defined in [types.ts:149](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L149)_
+_Defined in [types.ts:173](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L173)_
 
 Get the current x/y translation
 
@@ -493,7 +533,7 @@ Get the current x/y translation
 
 • **getScale**: _function_
 
-_Defined in [types.ts:151](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L151)_
+_Defined in [types.ts:175](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L175)_
 
 Get the current scale
 
@@ -507,7 +547,7 @@ Get the current scale
 
 • **pan**: _function_
 
-_Defined in [types.ts:164](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L164)_
+_Defined in [types.ts:188](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L188)_
 
 Pan the Panzoom element to the given x and y coordinates
 
@@ -536,7 +576,7 @@ panzoom.pan(10, 10, { relative: true })
 
 • **reset**: _function_
 
-_Defined in [types.ts:175](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L175)_
+_Defined in [types.ts:199](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L199)_
 
 Reset the pan and zoom to startX, startY, and startScale.
 Animates by default, ignoring the global option.
@@ -563,7 +603,7 @@ panzoom.reset({ animate: false })
 
 • **setOptions**: _function_
 
-_Defined in [types.ts:177](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L177)_
+_Defined in [types.ts:201](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L201)_
 
 Change options for the Panzoom instance
 
@@ -583,7 +623,7 @@ Change options for the Panzoom instance
 
 • **setStyle**: _function_
 
-_Defined in [types.ts:179](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L179)_
+_Defined in [types.ts:203](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L203)_
 
 A convenience method for setting prefixed styles on the Panzoom element
 
@@ -604,7 +644,7 @@ A convenience method for setting prefixed styles on the Panzoom element
 
 • **zoom**: _function_
 
-_Defined in [types.ts:188](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L188)_
+_Defined in [types.ts:212](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L212)_
 
 Zoom the Panzoom element to the given scale
 
@@ -630,7 +670,7 @@ panzoom.zoom(2.2, { animate: true })
 
 • **zoomIn**: _function_
 
-_Defined in [types.ts:199](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L199)_
+_Defined in [types.ts:223](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L223)_
 
 Zoom in using the predetermined increment set in options.
 Animates by default, ignoring the global option.
@@ -657,7 +697,7 @@ panzoom.zoomIn({ animate: false })
 
 • **zoomOut**: _function_
 
-_Defined in [types.ts:210](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L210)_
+_Defined in [types.ts:234](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L234)_
 
 Zoom out using the predetermined increment set in options.
 Animates by default, ignoring the global option.
@@ -684,7 +724,7 @@ panzoom.zoomOut({ animate: false })
 
 • **zoomToPoint**: _function_
 
-_Defined in [types.ts:221](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L221)_
+_Defined in [types.ts:245](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L245)_
 
 Zoom the Panzoom element to a focal point using
 the given pointer/touch/mouse event or constructed point.
@@ -718,7 +758,7 @@ panzoom.zoomToPoint(1.2, pointerEvent)
 
 • **zoomWithWheel**: _function_
 
-_Defined in [types.ts:250](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L250)_
+_Defined in [types.ts:274](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L274)_
 
 Zoom the Panzoom element to a focal point using the given WheelEvent
 
@@ -762,7 +802,7 @@ elem.parentElement.addEventListener('wheel', function(event) {
 
 • **scale**: _number_
 
-_Defined in [types.ts:142](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L142)_
+_Defined in [types.ts:166](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L166)_
 
 ---
 
@@ -770,7 +810,7 @@ _Defined in [types.ts:142](https://github.com/timmywil/panzoom/blob/e8f5210/src/
 
 • **x**: _number_
 
-_Defined in [types.ts:140](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L140)_
+_Defined in [types.ts:164](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L164)_
 
 ---
 
@@ -778,7 +818,7 @@ _Defined in [types.ts:140](https://github.com/timmywil/panzoom/blob/e8f5210/src/
 
 • **y**: _number_
 
-_Defined in [types.ts:141](https://github.com/timmywil/panzoom/blob/e8f5210/src/types.ts#L141)_
+_Defined in [types.ts:165](https://github.com/timmywil/panzoom/blob/5a075a0/src/types.ts#L165)_
 
 ## Events
 

--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -27,6 +27,10 @@ const defaultOptions: PanzoomOptions = {
   easing: 'ease-in-out',
   exclude: [],
   excludeClass: 'panzoom-exclude',
+  handleStartEvent: (e: Event) => {
+    e.preventDefault()
+    e.stopPropagation()
+  },
   maxScale: 4,
   minScale: 0.125,
   panOnlyWhenZoomed: false,
@@ -348,8 +352,7 @@ function Panzoom(
     }
     addPointer(pointers, event)
     isPanning = true
-    event.preventDefault()
-    event.stopPropagation()
+    options.handleStartEvent(event)
     origX = x
     origY = y
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,30 @@ interface MiscOptions {
    */
   force?: boolean
   /**
+   * On the first pointer event, when panning starts,
+   * the default Panzoom behavior is to call
+   * `event.preventDefault()` and `event.stopPropagation()`
+   * on that event. The former is almost certainly a necesity,
+   * the latter enables Panzoom elements within Panzoom elements.
+   *
+   * But there are some cases where the default is
+   * not the desired behavior. Set this option to override that behavior.
+   *
+   * ```js
+   * // Only call preventDefault()
+   * Panzoom(elem, {
+   *   handleStartEvent: (event) => {
+   *     event.preventDefault()
+   *   }
+   * })
+   * // Do nothing (this probably breaks things on mobile tho)
+   * Panzoom(elem, {
+   *   handleStartEvent: () => {}
+   * })
+   * ```
+   */
+  handleStartEvent?: (event: Event) => void
+  /**
    * **Change this at your own risk.**
    * The `transform-origin` is the origin from which transforms are applied.
    * Default: `'50% 50%'` for HTML and `'0 0'` for SVG.

--- a/test/unit/panzoom.test.ts
+++ b/test/unit/panzoom.test.ts
@@ -98,6 +98,7 @@ describe('Panzoom', () => {
       pan = panzoom.getPan()
       assert.equal(pan.x, 1)
       assert.equal(pan.y, 1)
+      document.body.removeChild(div)
     })
     it('ignores disableZoom', () => {
       const div = document.createElement('div')
@@ -112,6 +113,7 @@ describe('Panzoom', () => {
       panzoom.zoom(2, { force: true })
       scale = panzoom.getScale()
       assert.equal(scale, 2)
+      document.body.removeChild(div)
     })
     it('ignores panOnlyWhenZoomed', () => {
       const div = document.createElement('div')
@@ -128,6 +130,22 @@ describe('Panzoom', () => {
       pan = panzoom.getPan()
       assert.equal(pan.x, 1)
       assert.equal(pan.y, 1)
+      document.body.removeChild(div)
+    })
+  })
+  it('calls the handleStartEvent option', () => {
+    return new Promise((resolve) => {
+      const div = document.createElement('div')
+      document.body.appendChild(div)
+      Panzoom(div, {
+        handleStartEvent: (event: Event) => {
+          event.preventDefault()
+          assert.ok('handleStartEvent called')
+          resolve()
+        }
+      })
+      div.dispatchEvent(new PointerEvent('pointerdown'))
+      document.body.removeChild(div)
     })
   })
 })


### PR DESCRIPTION
Fixes gh-414

### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [x] I have run `yarn test` against my changes and tests pass.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary types and generated documentation (`yarn docs`), or no docs changes are needed.

### Description

<!--Please describe your pull request. Thank you!-->

This adds the `handleStartEvent` option to handle whether `event.preventDefault()` or `event.stopPropagation()` are called on the start event. The default is to call both.

**Fixes**: gh-414

<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/timmywil/panzoom/issues).-->
