### PR TITLE
 feat(panzoom): add pan option - roundToPixels

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -73,6 +73,10 @@ export function setTransform(
   { x, y, scale, isSVG }: CurrentValues,
   _options?: PanzoomOptions
 ) {
+  if (_options !== undefined && _options.roundToPixels) {
+    x = Math.round(x)
+    y = Math.round(y)
+  }
   setStyle(elem, 'transform', `scale(${scale}) translate(${x}px, ${y}px)`)
   if (isSVG && isIE) {
     const matrixValue = window.getComputedStyle(elem).getPropertyValue('transform')

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,8 @@ interface PanSpecificOptions {
   relative?: boolean
   /** Disable panning while the scale is equal to the starting value */
   panOnlyWhenZoomed?: boolean
+  /** Round transform-translate x and values to whole pixels. (Prevents images getting blurry)  */
+  roundToPixels?: boolean
 }
 
 interface ZoomSpecificOptions {

--- a/test/unit/css.test.ts
+++ b/test/unit/css.test.ts
@@ -42,5 +42,15 @@ describe('css', () => {
       setTransform(elem, { x: 1, y: 1, scale: 1 })
       assertStyle(elem, 'transform', 'scale(1) translate(1px, 1px)')
     })
+    it('sets the default transform-origin property with roundToPixels = true for HTML', () => {
+      const elem = document.createElement('div')
+      setTransform(elem, { x: 1.25, y: 1.75, scale: 1 }, { roundToPixels: true })
+      assertStyle(elem, 'transform', 'scale(1) translate(1px, 2px)')
+    })
+    it('sets the default transform-origin property with roundToPixels = true for SCG', () => {
+      const elem = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+      setTransform(elem, { x: 1.25, y: 1.75, scale: 1 }, { roundToPixels: true })
+      assertStyle(elem, 'transform', 'scale(1) translate(1px, 2px)')
+    })
   })
 })


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary types and generated documentation (`npm run docs`), or no docs changes are needed.

### Description
If roundToPixels is set to true, X and Y in `translate(Xpx, Ypx)` are rounded to integers. The prevents Chrome (and possibly other webkit browsers) from making images blurry.

**Fixes**:
Possibly related: #343, #264, #100

My experience with this fix is that it is especially noticeable on text or things with sharp edges.
`roundToPixels: false`
![2020-04-11_19-01](https://user-images.githubusercontent.com/30637897/79049964-2edc9c00-7c27-11ea-9715-4a0596d0496c.png)
`roundToPixels: true`
![2020-04-11_19-03](https://user-images.githubusercontent.com/30637897/79049967-313ef600-7c27-11ea-862e-33738197782d.png)