### PR TITLE
Pinch zoom moves image away from screen center

### DIFF
--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -458,19 +458,23 @@ function Panzoom(
     if (pointers.length > 1) {
       // Use the distance between the first 2 pointers
       // to determine the current scale
+      // prevent zoom issue in mobile
+      if (startDistance === 0) {
+        startDistance = getDistance(pointers);
+      }
       const diff = getDistance(pointers) - startDistance
       const toScale = constrainScale((diff * options.step) / 80 + startScale).scale
       zoomToPoint(toScale, current)
+    } else {
+      // added else condition to prevent mobile zoom focal point error
+      pan(
+        origX + (current.clientX - startClientX) / scale,
+        origY + (current.clientY - startClientY) / scale,
+        {
+          animate: false
+        }
+      );
     }
-
-    pan(
-      origX + (current.clientX - startClientX) / scale,
-      origY + (current.clientY - startClientY) / scale,
-      {
-        animate: false
-      },
-      event
-    )
   }
 
   function handleUp(event: PointerEvent) {


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *master*.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary types and generated documentation (`npm run docs`), or no docs changes are needed.

### Description
Pinch zoom moves image away from screen center due to pan function updates x and y values while zoom function in progress on mobile devices and causes focal point error
<!--Please describe your pull request. Thank you!-->

**Fixes**: 
[512 - Pinch zoom moves image away from screen center](https://github.com/timmywil/panzoom/issues/512)

<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/timmywil/panzoom/issues).-->
