### PR TITLE
adds smart constrain to allow for objects with x/y being inside/outside

### DIFF
--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -226,8 +226,8 @@ function Panzoom(
       const scaledHeight = realHeight * toScale
       const diffHorizontal = (scaledWidth - realWidth) / 2
       const diffVertical = (scaledHeight - realHeight) / 2
-      let smartX = dims.parent.width > scaledWidth ? 'inside' : 'outside'
-      let smartY = dims.parent.height > scaledHeight ? 'inside' : 'outside'
+      const smartX = dims.parent.width > scaledWidth ? 'inside' : 'outside'
+      const smartY = dims.parent.height > scaledHeight ? 'inside' : 'outside'
 
       if (opts.contain === 'inside' || smartX === 'inside') {
         const minX = (-dims.elem.margin.left - dims.parent.padding.left + diffHorizontal) / toScale

--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -226,8 +226,10 @@ function Panzoom(
       const scaledHeight = realHeight * toScale
       const diffHorizontal = (scaledWidth - realWidth) / 2
       const diffVertical = (scaledHeight - realHeight) / 2
+      let smartX = dims.parent.width > scaledWidth ? 'inside' : 'outside'
+      let smartY = dims.parent.height > scaledHeight ? 'inside' : 'outside'
 
-      if (opts.contain === 'inside') {
+      if (opts.contain === 'inside' || smartX === 'inside') {
         const minX = (-dims.elem.margin.left - dims.parent.padding.left + diffHorizontal) / toScale
         const maxX =
           (dims.parent.width -
@@ -239,6 +241,8 @@ function Panzoom(
             diffHorizontal) /
           toScale
         result.x = Math.max(Math.min(result.x, maxX), minX)
+      }
+      if (opts.contain === 'inside' || smartY === 'inside') {
         const minY = (-dims.elem.margin.top - dims.parent.padding.top + diffVertical) / toScale
         const maxY =
           (dims.parent.height -
@@ -250,7 +254,8 @@ function Panzoom(
             diffVertical) /
           toScale
         result.y = Math.max(Math.min(result.y, maxY), minY)
-      } else if (opts.contain === 'outside') {
+      }
+      if (opts.contain === 'outside' || smartX === 'outside') {
         const minX =
           (-(scaledWidth - dims.parent.width) -
             dims.parent.padding.left -
@@ -260,6 +265,8 @@ function Panzoom(
           toScale
         const maxX = (diffHorizontal - dims.parent.padding.left) / toScale
         result.x = Math.max(Math.min(result.x, maxX), minX)
+      }
+      if (opts.contain === 'outside' || smartY === 'outside') {
         const minY =
           (-(scaledHeight - dims.parent.height) -
             dims.parent.padding.top -


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *main*.
- [x] I have run `yarn test` against my changes and tests pass.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary types and generated documentation (`yarn docs`), or no docs changes are needed.

### Description

<!--Please describe your pull request. Thank you!-->
Adds 'smart' to contain option, to add intelligent sensing to use 'outside' or 'inside' per x and y.

**Fixes**: #582 

<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/timmywil/panzoom/issues).-->