### PR TITLE
#582: Fix contain outside when element is smaller than parent

### DIFF
--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -259,7 +259,7 @@ function Panzoom(
             diffHorizontal) /
           toScale
         const maxX = (diffHorizontal - dims.parent.padding.left) / toScale
-        result.x = Math.max(Math.min(result.x, maxX), minX)
+        result.x = Math.max(Math.min(result.x, Math.max(minX, maxX)), Math.min(minX, maxX))
         const minY =
           (-(scaledHeight - dims.parent.height) -
             dims.parent.padding.top -
@@ -268,7 +268,7 @@ function Panzoom(
             diffVertical) /
           toScale
         const maxY = (diffVertical - dims.parent.padding.top) / toScale
-        result.y = Math.max(Math.min(result.y, maxY), minY)
+        result.y = Math.max(Math.min(result.y, Math.max(minY, maxY)), Math.min(minY, maxY))
       }
     }
     return result


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *main*.
- [X] I have run `yarn test` against my changes and tests pass.
- [ ] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [X] I have added or edited necessary types and generated documentation (`yarn docs`), or no docs changes are needed.

### Description

Debugging the contain outside option, I discovered that when the element is smaller than the parent, the min and max values determined for the x and y could actually be reversed (i.e. minX > maxX). When this occurs, the constrainXY function sets the result.x value to the minX and/or minY values, and glues the element to the bottom right corner of the parent, not allowing any movement (bottom right as both minX and minY are actually the max values).

**Fixes**: #582

Obsoletes #583, which should be closed.