### PR TITLE
feat: support attached shadow dom elements

### DIFF
--- a/src/isAttached.ts
+++ b/src/isAttached.ts
@@ -2,16 +2,14 @@
  * Determine if an element is attached to the DOM
  * Panzoom requires this so events work properly
  */
-export default function isAttached(elem: HTMLElement | SVGElement | Document) {
-  const doc = elem.ownerDocument
-  const rootNode = elem.getRootNode()
-  const parent = rootNode instanceof ShadowRoot ? rootNode.host : elem.parentNode
-
-  return (
-    doc &&
-    parent &&
-    doc.nodeType === 9 &&
-    parent.nodeType === 1 &&
-    doc.documentElement.contains(parent)
-  )
+export default function isAttached(node: Node) {
+  let currentNode = node
+  while (currentNode && currentNode.parentNode) {
+    if (currentNode.parentNode === document) return true
+    currentNode =
+      currentNode.parentNode instanceof ShadowRoot
+        ? currentNode.parentNode.host
+        : currentNode.parentNode
+  }
+  return false
 }

--- a/src/isAttached.ts
+++ b/src/isAttached.ts
@@ -4,7 +4,9 @@
  */
 export default function isAttached(elem: HTMLElement | SVGElement | Document) {
   const doc = elem.ownerDocument
-  const parent = elem.parentNode
+  const rootNode = elem.getRootNode()
+  const parent = rootNode instanceof ShadowRoot ? rootNode.host : elem.parentNode
+
   return (
     doc &&
     parent &&

--- a/test/unit/isAttached.test.ts
+++ b/test/unit/isAttached.test.ts
@@ -8,6 +8,20 @@ describe('isAttached', () => {
     assert(isAttached(div))
     document.body.removeChild(div)
   })
+  it('determines if an attached shadow dom element is attached', () => {
+    const div = document.createElement('div')
+    const shadowChild = document.createElement('div')
+    div.attachShadow({ mode: 'open' }).appendChild(shadowChild)
+    document.body.appendChild(div)
+    assert(isAttached(shadowChild))
+    document.body.removeChild(div)
+  })
+  it('determines if a detached shadow dom element is attached', () => {
+    const div = document.createElement('div')
+    const shadowChild = document.createElement('div')
+    div.attachShadow({ mode: 'open' }).appendChild(shadowChild)
+    assert(!isAttached(shadowChild))
+  })
   it('determines if a detached element is attached', () => {
     const div = document.createElement('div')
     assert(!isAttached(div))

--- a/test/unit/isAttached.test.ts
+++ b/test/unit/isAttached.test.ts
@@ -16,6 +16,16 @@ describe('isAttached', () => {
     assert(isAttached(shadowChild))
     document.body.removeChild(div)
   })
+  it('determines if a nested, attached shadow dom element is attached', () => {
+    const div = document.createElement('div')
+    const shadowChild = document.createElement('div')
+    const shadowGrandChild = document.createElement('div')
+    shadowChild.attachShadow({ mode: 'open' }).appendChild(shadowGrandChild)
+    div.attachShadow({ mode: 'open' }).appendChild(shadowChild)
+    document.body.appendChild(div)
+    assert(isAttached(shadowGrandChild))
+    document.body.removeChild(div)
+  })
   it('determines if a detached shadow dom element is attached', () => {
     const div = document.createElement('div')
     const shadowChild = document.createElement('div')


### PR DESCRIPTION
### PR Checklist

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] I am requesting to **pull a topic/feature/bugfix branch** (right side). In other words, not *main*.
- [X] I have run `yarn test` against my changes and tests pass.
- [X] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [X] I have added or edited necessary types and generated documentation (`yarn docs`), or no docs changes are needed.

### Description

<!--Please describe your pull request. Thank you!-->
Updates the `isAttached` helper to handle shadow dom elements. ~~If the passed element's root node is a ShadowRoot, it sets `parent` to the ShadowRoot's host and subsequently checks if the host is attached; otherwise it falls back to the pre-existing functionality.~~

With additional testing, I found that the prior change was not sufficient to handle multiple nested shadow dom elements. The logic has been updated to manually traverse through the dom (handling both regular & shadow nodes) to ensure that any nesting is properly accounted for.

**Fixes**: #536

<!--List the issue this PR is fixing. If one does not exist, please [create one](https://github.com/timmywil/panzoom/issues).-->
