### PR TITLE
feat: new aspectfit contain mode

### DIFF
--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -203,7 +203,7 @@ function Panzoom(
       const diffHorizontal = (scaledWidth - realWidth) / 2
       const diffVertical = (scaledHeight - realHeight) / 2
 
-      if (opts.contain === 'inside') {
+      if (opts.contain === 'inside' || ( opts.contain === 'aspectfit' && scaledWidth <= dims.parent.width)) {
         const minX = (-dims.elem.margin.left - dims.parent.padding.left + diffHorizontal) / toScale
         const maxX =
           (dims.parent.width -
@@ -226,7 +226,7 @@ function Panzoom(
             diffVertical) /
           toScale
         result.y = Math.max(Math.min(result.y, maxY), minY)
-      } else if (opts.contain === 'outside') {
+      } else if (opts.contain === 'outside' || ( opts.contain === 'aspectfit' && scaledWidth > dims.parent.width)) {
         const minX =
           (-(scaledWidth - dims.parent.width) -
             dims.parent.padding.left -
@@ -279,6 +279,9 @@ function Panzoom(
           maxScale = Math.min(maxScale, elemScaledWidth, elemScaledHeight)
         } else if (options.contain === 'outside') {
           minScale = Math.max(minScale, elemScaledWidth, elemScaledHeight)
+        } else if (options.contain==='aspectfit') {
+          // maxScale = Math.min(maxScale, elemScaledWidth, elemScaledHeight)
+          // minScale = Math.max(minScale, elemScaledWidth, elemScaledHeight)
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,7 @@ export interface PanOnlyOptions {
    *
    * **Note**: the containment pan adjustment is not affected by the `disablePan` option.
    */
-  contain?: 'inside' | 'outside'
+  contain?: 'inside' | 'outside' | 'aspectfit'
   /** The cursor style to set on the panzoom element */
   cursor?: string
   /**


### PR DESCRIPTION
this creates a new contain mode which is kind of a mix of `outside` and `inside`.
You can zoom out to see the full view while blocking the panning while zoomed in to the bounds of the view